### PR TITLE
Disable coverage on hhvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ install:
   - composer install --prefer-source
 
 script:
-  - ./vendor/bin/phpunit --coverage-clover=coverage.clover
-  - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+  - ./vendor/bin/phpunit --coverage-clover ./clover.xml
+  - if [ $TRAVIS_PHP_VERSION != 'hhvm' ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
+  - if [ $TRAVIS_PHP_VERSION != 'hhvm' ]; then php ocular.phar code-coverage:upload --format=php-clover ./clover.xml; fi


### PR DESCRIPTION
Here I disabled sending coverage under hhvm.
Coverage must not be generated under hhvm until until there is something that can generate something like a `clover.xml`.
