### PR TITLE
Addresses Strict Warnings

### DIFF
--- a/src/Core/Application.php
+++ b/src/Core/Application.php
@@ -9,7 +9,7 @@ use Zend\Console\Adapter\AdapterInterface as Console;
 use Zend\Console\Console as DefaultConsole;
 use ZF\Console\RouteCollection;
 use ZF\Console\Application as ZfApplication;
-use ZF\Console\Dispatcher;
+use ZF\Console\DispatcherInteface;
 
 class Application extends ZfApplication
 {
@@ -29,21 +29,21 @@ class Application extends ZfApplication
         );
     }
 
-    protected function setupHelpCommand(RouteCollection $routeCollection, Dispatcher $dispatcher)
+    protected function setupHelpCommand(RouteCollection $routeCollection, DispatcherInterface $dispatcher)
     {
         if ($dispatcher instanceof AppDispatcher) {
             return parent::setupHelpCommand($routeCollection, $dispatcher);
         }
     }
 
-    protected function setupVersionCommand(RouteCollection $routeCollection, Dispatcher $dispatcher)
+    protected function setupVersionCommand(RouteCollection $routeCollection, DispatcherInterface $dispatcher)
     {
         if ($dispatcher instanceof AppDispatcher) {
             return parent::setupVersionCommand($routeCollection, $dispatcher);
         }
     }
 
-    protected function setupAutocompleteCommand(RouteCollection $routeCollection, Dispatcher $dispatcher)
+    protected function setupAutocompleteCommand(RouteCollection $routeCollection, DispatcherInterface $dispatcher)
     {
         if ($dispatcher instanceof AppDispatcher) {
             return parent::setupAutocompleteCommand($routeCollection, $dispatcher);


### PR DESCRIPTION
Observed ```PHP Strict standards:  Declaration of App\Core\Application::setupHelpCommand() should be compatible with ZF\Console\Application::setupHelpCommand(ZF\Console\RouteCollection $routeCollection, ZF\Console\DispatcherInterface $dispatcher)```